### PR TITLE
Chore: fix getReservesAtPrice by reverting on invalid active reserves

### DIFF
--- a/src/SOT.sol
+++ b/src/SOT.sol
@@ -72,6 +72,7 @@ contract SOT is ISovereignALM, ISwapFeeModule, ISOT, EIP712, SOTOracle {
     error SOT__setMaxAllowedQuotes_invalidMaxAllowedQuotes();
     error SOT__setMaxOracleDeviationBips_exceedsMaxDeviationBounds();
     error SOT__setPriceBounds_spotPriceAndOracleDeviation();
+    error SOT__getReservesAtPrice_invalidActiveReserves();
     error SOT__setSolverFeeInBips_invalidSolverFee();
     error SOT___checkSpotPriceRange_invalidSqrtSpotPriceX96(uint160 sqrtSpotPriceX96);
     error SOT___ammSwap_invalidSpotPriceAfterSwap();
@@ -353,6 +354,10 @@ contract SOT is ISovereignALM, ISwapFeeModule, ISOT, EIP712, SOTOracle {
             sqrtPriceHighX96,
             effectiveAMMLiquidityCache
         );
+
+        if(activeReserve0 > reserve0 || activeReserve1 > reserve1){
+            revert SOT__getReservesAtPrice_invalidActiveReserves();
+        }
 
         uint256 passiveReserve0 = reserve0 - activeReserve0;
         uint256 passiveReserve1 = reserve1 - activeReserve1;

--- a/test/concrete/SOTConcrete.t.sol
+++ b/test/concrete/SOTConcrete.t.sol
@@ -186,6 +186,9 @@ contract SOTConcreteTest is SOTBase {
         token1.transfer(address(1), preState.reserve1/2);
         vm.stopPrank();
 
+        vm.expectRevert(SOT.SOT__getReservesAtPrice_invalidActiveReserves.selector);
+        sot.getReservesAtPrice(preState.sqrtSpotPriceX96);
+
         (uint256 amountInUsedRebase, uint256 amountOutRebase) = pool.swap(params);
 
         (uint160 sqrtSpotPriceX96Rebase, , ) = sot.getAMMState();


### PR DESCRIPTION
If statemind doesn't agree with our approach as implemented in PR #40 , this can be merged which uses their current recommendation.