### PR TITLE
chore: add HOT example for partially filled order

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "query:HOT": "forge script scripts/utils/HOTQuery.s.sol:HOTQueryScript --rpc-url ",
     "deposit:HOT": "forge script scripts/deposit/HOTDeposit.s.sol:HOTDepositScript --rpc-url ",
     "demo-viem:HOT": "npx ts-node scripts/hot-example/demo-viem.ts",
+    "demo-viem:HOT-partial-fill": "npx ts-node scripts/hot-example/demo-viem-partial-fill.ts",
     "demo-ethers:HOT": "npx ts-node scripts/hot-example/demo-ethers.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "deposit:HOT": "forge script scripts/deposit/HOTDeposit.s.sol:HOTDepositScript --rpc-url ",
     "demo-viem:HOT": "npx ts-node scripts/hot-example/demo-viem.ts",
     "demo-viem:HOT-partial-fill": "npx ts-node scripts/hot-example/demo-viem-partial-fill.ts",
-    "demo-ethers:HOT": "npx ts-node scripts/hot-example/demo-ethers.ts"
+    "demo-ethers:HOT": "npx ts-node scripts/hot-example/demo-ethers.ts",
+    "demo-ethers:HOT-partial-fill": "npx ts-node scripts/hot-example/demo-ethers-partial-fill.ts"
   },
   "dependencies": {
     "@nomicfoundation/hardhat-foundry": "^1.1.1",

--- a/scripts/hot-example/demo-ethers.ts
+++ b/scripts/hot-example/demo-ethers.ts
@@ -1,14 +1,6 @@
 import { AddressLike, Wallet, ethers } from 'ethers';
 
-async function fetchAmountOut(amountIn: bigint): Promise<bigint> {
-  const response = await fetch('https://api.binance.com/api/v3/ticker/price?symbol=ETHUSDC');
-  const priceResult = (await response.json()) as {
-    symbol: string;
-    price: string;
-  };
-
-  return (BigInt(priceResult.price.split('.')[0]) * amountIn) / BigInt(10) ** BigInt(12);
-}
+import { fetchAmountOut } from './utils/price-api';
 
 async function swap() {
   const headers = {

--- a/scripts/hot-example/demo-viem-partial-fill.ts
+++ b/scripts/hot-example/demo-viem-partial-fill.ts
@@ -1,7 +1,7 @@
 import { privateKeyToAccount } from 'viem/accounts';
 import { gnosis } from 'viem/chains';
-import { Address, createWalletClient, http, publicActions } from 'viem';
-import { SignTypedDataReturnType } from 'viem';
+import { Address, createWalletClient, encodeAbiParameters, http, parseAbiParameters, publicActions } from 'viem';
+import { SignTypedDataReturnType, decodeAbiParameters } from 'viem';
 
 async function fetchAmountOut(amountIn: bigint): Promise<bigint> {
   const response = await fetch('https://api.binance.com/api/v3/ticker/price?symbol=ETHUSDC');
@@ -13,7 +13,7 @@ async function fetchAmountOut(amountIn: bigint): Promise<bigint> {
   return (BigInt(priceResult.price.split('.')[0]) * amountIn) / BigInt(10) ** BigInt(12);
 }
 
-async function swap() {
+async function swapPartialFill() {
   const headers = {
     'Content-Type': 'application/json',
     'X-API-Key': `${process.env.API_KEY}`,
@@ -30,14 +30,12 @@ async function swap() {
     authorized_recipient: account.address, // address which receives token out
     authorized_sender: account.address, // should be same address which calls pool contract
     chain_id: 100, // 1 for mainnet, 100 for gnosis
-    token_in: '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1', // weth on gnosis (0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 for mainnet)
-    token_out: '0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83', // USDC on gnosis (0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 for mainnet)
-    expected_gas_price: '0',
-    expected_gas_units: '0',
+    token_in: '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1', // weth on gnosis
+    token_out: '0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83', // USDC on gnosis
+    expected_gas_price: '0', // 1 gwei gas price
     volume_token_in: AMOUNT_IN.toString(),
     volume_token_out_min: AMOUNT_OUT.toString(),
-    request_expiry: Math.ceil(Date.now() / 1000) + 30, // Expiry in 30 seconds,
-    quote_expiry: Math.ceil(Date.now() / 1000) + 120, // Quote valid for 120 seconds
+    request_expiry: Math.ceil(Date.now() / 1000) + 30, // Expiry in 30 seconds
   });
 
   const requestOptions: RequestInit = {
@@ -57,8 +55,8 @@ async function swap() {
   const walletClient = createWalletClient({
     name: 'Main',
     account,
-    chain: gnosis, // set to `mainnet` for mainnet
-    transport: http(`${process.env.GNOSIS_RPC}`), //Set to MAINNET_RPC for mainnet
+    chain: gnosis,
+    transport: http(`${process.env.GNOSIS_RPC}`),
   }).extend(publicActions);
 
   if (!quote.signed_payload) {
@@ -66,16 +64,46 @@ async function swap() {
     return;
   }
 
+  // Human readable ABI params from SovereignPool::swap (pool_address)
+  const swapAbiParams = parseAbiParameters(
+    '(bool isSwapCallback, bool isZeroToOne, uint256 amountIn, uint256 amountOutMin, uint256 deadline, address recipient, address swapTokenOut, (bytes externalContext, bytes verifierContext, bytes swapCallbackContext, bytes swapFeeModuleContext))'
+  );
+
+  // Decode signed_payload
+  const payloadSliced = `0x${quote.signed_payload.slice(10)}`;
+  const decodedParams = decodeAbiParameters(swapAbiParams, payloadSliced as `0x{string}`)[0];
+
+  // Recalculate amountIn and amountOutMin to execute a partially fillable HOT swap
+  const amountInPartialFill = AMOUNT_IN / BigInt('2');
+  const amountOutMinPartialFill = AMOUNT_OUT / BigInt('2');
+
+  // Re-encode payload with amountInPartialFill and amountOutMinPartialFill
+  const encodedParamsPartialFill = encodeAbiParameters(swapAbiParams, [
+    [
+      decodedParams[0],
+      decodedParams[1],
+      amountInPartialFill,
+      amountOutMinPartialFill,
+      decodedParams[4],
+      decodedParams[5],
+      decodedParams[6],
+      decodedParams[7],
+    ],
+  ]);
+  const payloadPartialFill = `0x${quote.signed_payload.slice(2, 10)}${encodedParamsPartialFill.slice(
+    2
+  )}` as `0x{string}`;
+
   const txHash = await walletClient.sendTransaction({
     account,
     chain: gnosis,
     to: quote.pool_address,
     value: 0n,
-    data: quote.signed_payload,
+    data: payloadPartialFill,
     gas: 1_000_000n,
   });
 
   console.log(txHash);
 }
 
-swap();
+swapPartialFill();

--- a/scripts/hot-example/demo-viem.ts
+++ b/scripts/hot-example/demo-viem.ts
@@ -3,15 +3,7 @@ import { gnosis } from 'viem/chains';
 import { Address, createWalletClient, http, publicActions } from 'viem';
 import { SignTypedDataReturnType } from 'viem';
 
-async function fetchAmountOut(amountIn: bigint): Promise<bigint> {
-  const response = await fetch('https://api.binance.com/api/v3/ticker/price?symbol=ETHUSDC');
-  const priceResult = (await response.json()) as {
-    symbol: string;
-    price: string;
-  };
-
-  return (BigInt(priceResult.price.split('.')[0]) * amountIn) / BigInt(10) ** BigInt(12);
-}
+import { fetchAmountOut } from './utils/price-api';
 
 async function swap() {
   const headers = {

--- a/scripts/hot-example/utils/price-api.ts
+++ b/scripts/hot-example/utils/price-api.ts
@@ -1,0 +1,9 @@
+export async function fetchAmountOut(amountIn: bigint): Promise<bigint> {
+  const response = await fetch('https://api.binance.com/api/v3/ticker/price?symbol=ETHUSDC');
+  const priceResult = (await response.json()) as {
+    symbol: string;
+    price: string;
+  };
+
+  return (BigInt(priceResult.price.split('.')[0]) * amountIn) / BigInt(10) ** BigInt(12);
+}


### PR DESCRIPTION
Added HOT swap example with a partially fillable order, in ethers js and viem.

After obtaining the payload from the Valantis HOT endpoint, it can be decoded to replace amountIn and amountOutMin with different values, then re-encode and submit the swap.